### PR TITLE
Allow newer versions of pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,6 @@
 	"types": "./dist/index.d.ts",
 	"packageManager": "pnpm@7.28.0",
 	"engines": {
-		"pnpm": "^7.0.0"
+		"pnpm": ">=7.0.0"
 	}
 }


### PR DESCRIPTION
I'm new to pnpm, so please correct me if it is a bad idea.

Currently I can't reference svelte-icons in a project that uses a newer version of pnpm. Changing the requirement to accept any version >= 7 seems to work in my testing.